### PR TITLE
Handling edges with no type at or a type:None

### DIFF
--- a/reasoner_converter/upgrading.py
+++ b/reasoner_converter/upgrading.py
@@ -13,6 +13,8 @@ def upgrade_BiolinkEntity(biolink_entity):
 
 def upgrade_BiolinkRelation(biolink_relation):
     """Upgrade BiolinkRelation from 0.9.2 to 1.0.0."""
+    if biolink_relation is None:
+        return None
     if biolink_relation.startswith("biolink:"):
         return biolink_relation
     return "biolink:" + snake_case(biolink_relation)
@@ -33,12 +35,13 @@ def upgrade_Node(node):
 
 def upgrade_Edge(edge):
     """Upgrade Edge from 0.9.2 to 1.0.0."""
-    return {
-        "predicate": upgrade_BiolinkRelation(edge["type"]),
+    newedge = {
         "subject": edge["source_id"],
         "object": edge["target_id"],
     }
-
+    if 'type' in edge:
+        newedge["predicate"] = upgrade_BiolinkRelation(edge["type"])
+    return newedge
 
 def upgrade_KnowledgeGraph(kgraph):
     """Upgrade KnowledgeGraph from 0.9.2 to 1.0.0."""

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -32,6 +32,33 @@ def test_092_edge_type_curie():
         "object": "HGNC:4897",
     }
 
+def test_no_edge_type():
+    """Test upgrading a 0.9.2 edge without a type."""
+    kedge0 = {
+        "id": "xxx",
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:4897",
+    }
+    kedge1 = upgrade_Edge(kedge0)
+    assert kedge1 == {
+        "subject": "MONDO:0005737",
+        "object": "HGNC:4897",
+    }
+
+def test_none_edge_type():
+    """Test upgrading a 0.9.2 edge without an edge that has type:None."""
+    kedge0 = {
+        "id": "xxx",
+        "type": None,
+        "source_id": "MONDO:0005737",
+        "target_id": "HGNC:4897",
+    }
+    kedge1 = upgrade_Edge(kedge0)
+    assert kedge1 == {
+        "predicate": None,
+        "subject": "MONDO:0005737",
+        "object": "HGNC:4897",
+    }
 
 def test_100_qnode_category_list():
     """Test downgrading a 1.0.0 qnode category that's a list."""


### PR DESCRIPTION
Was using this to convert some of the test json files for answercoalesce, which were built by strider and robokop.

Encountered a problem when an edge was missing the type attribute, or where null or None was the value of the attribute.

I think that in both 0.9.2 and 1.0 type(predicate) is not a required field, so it's ok if it's not there.

I'm less sure if type:None is valid or not.  I updated the code to handle both cases (and added tests).